### PR TITLE
Added C# wrapper from Johnny Arguelles

### DIFF
--- a/source/includes/_wrappers.md.erb
+++ b/source/includes/_wrappers.md.erb
@@ -45,6 +45,11 @@ offering on GitHub.
 
 ## C&#35;
 
+Johnny Arguelles of CollabCoders made his extension of [John Siladie](https://github.com/nofxsnap)’s
+wrapper available on [NuGet](https://www.nuget.org/packages/CheddarGetter.CollabCoders).
+
+* [https://github.com/collabcoders/CheddarGetter](https://github.com/collabcoders/CheddarGetter)
+
 Take a look at [Nathan Arnolds](http://www.shorepound.net/)'s fork of
 [John Siladie](https://github.com/nofxsnap)'s initial release.
 


### PR DESCRIPTION
Per [github ticket #1220](https://github.com/chdr/cheddargetter/issues/1220) and the [support forum comment](http://support.getcheddar.com/discussions/questions/24667-fyii-made-a-net-core-2-service-wrapper-with-dependency-injection-for-chettargetter) from Johnny Arguelles