### PR TITLE
Added Google Tag Manager

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-docs.getcheddar.com

--- a/source/CNAME
+++ b/source/CNAME
@@ -1,1 +1,1 @@
-docs.cheddargetter.com
+docs.getcheddar.com

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -17,6 +17,10 @@ under the License.
 <!doctype html>
 <html>
   <head>
+    <!-- Google Tag Manager -->
+    <%= yield %>
+    <%= partial "partials/google-tag-script" %>
+    <!-- End Google Tag Manager -->
     <meta charset="utf-8">
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
@@ -35,6 +39,10 @@ under the License.
   </head>
 
   <body class="<%= page_classes %>" data-languages="<%=h language_tabs.map{ |lang| lang.is_a?(Hash) ? lang.keys.first : lang }.to_json %>">
+    <!-- Google Tag Manager (noscript) -->
+    <%= yield %>
+    <%= partial "partials/google-tag-noscript" %>
+    <!-- End Google Tag Manager (noscript) -->
     <a href="#" id="nav-button">
       <span>
         NAV

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -17,10 +17,12 @@ under the License.
 <!doctype html>
 <html>
   <head>
-    <!-- Google Tag Manager -->
-    <%= yield %>
-    <%= partial "partials/google-tag-script" %>
-    <!-- End Google Tag Manager -->
+    <% if build? %>
+      <!-- Google Tag Manager -->
+      <%= yield %>
+      <%= partial "partials/google-tag-script" %>
+      <!-- End Google Tag Manager -->
+    <% end %>
     <meta charset="utf-8">
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
@@ -39,10 +41,12 @@ under the License.
   </head>
 
   <body class="<%= page_classes %>" data-languages="<%=h language_tabs.map{ |lang| lang.is_a?(Hash) ? lang.keys.first : lang }.to_json %>">
-    <!-- Google Tag Manager (noscript) -->
-    <%= yield %>
-    <%= partial "partials/google-tag-noscript" %>
-    <!-- End Google Tag Manager (noscript) -->
+    <% if build? %>
+      <!-- Google Tag Manager (noscript) -->
+      <%= yield %>
+      <%= partial "partials/google-tag-noscript" %>
+      <!-- End Google Tag Manager (noscript) -->
+    <% end %>
     <a href="#" id="nav-button">
       <span>
         NAV

--- a/source/partials/_google-tag-noscript.erb
+++ b/source/partials/_google-tag-noscript.erb
@@ -1,0 +1,2 @@
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P4BFKHD"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/source/partials/_google-tag-script.erb
+++ b/source/partials/_google-tag-script.erb
@@ -1,0 +1,5 @@
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-P4BFKHD');</script>


### PR DESCRIPTION
The Google Tag Manager scripts have been added per our [ticket](https://github.com/chdr/cheddargetter/issues/1219).

Changes to the `CNAME` file should close our [deployment error](https://github.com/chdr/cheddargetter/issues/1222).
